### PR TITLE
통화 및 문자 연결 기능 구현 

### DIFF
--- a/phonebook/app/build.gradle.kts
+++ b/phonebook/app/build.gradle.kts
@@ -76,5 +76,8 @@ dependencies {
 
     // serialization
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.0")
+
+    // Navigation
+    implementation("androidx.navigation:navigation-compose:2.5.3")
 }
 

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/domain/model/Contact.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/domain/model/Contact.kt
@@ -6,6 +6,5 @@ import kotlinx.serialization.Serializable
 data class Contact(
     var name: String = "",
     var phoneNumber: String = "",
-//    var nickname: String = "",
-//    var email: String = ""
+    var favoriteStatus: Boolean = false
 )

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/navigation/NavGraph.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/navigation/NavGraph.kt
@@ -1,0 +1,53 @@
+package com.madcamp.phonebook.navigation
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.google.accompanist.pager.ExperimentalPagerApi
+import com.madcamp.phonebook.domain.model.Contact
+import com.madcamp.phonebook.presentation.contact.ContactDetailScreen
+import com.madcamp.phonebook.presentation.contact.ContactListScreen
+import com.madcamp.phonebook.presentation.contact.viewmodel.ContactViewModel
+import com.madcamp.phonebook.presentation.TabLayout
+
+@OptIn(ExperimentalPagerApi::class)
+@Composable
+fun NavGraph(
+    activity: ComponentActivity,
+    contactList: List<Contact>,
+    contactViewModel: ContactViewModel
+) {
+    val screen = Screen()
+    val navController = rememberNavController()
+
+    NavHost(
+        navController = navController,
+        startDestination = screen.MainScreen
+    ) {
+        composable(screen.MainScreen) {
+            TabLayout(contactList, navController)
+        }
+
+        composable(screen.ContactListScreen) {
+            ContactListScreen(
+                navController = navController,
+                contactList = contactList
+            )
+        }
+
+        composable(screen.ContactDetailScreen + "/{contactNumber}",
+            arguments = listOf(navArgument("contactNumber") { type = NavType.StringType })
+        ) {
+            ContactDetailScreen(
+                navController = navController,
+                contactList = contactList,
+                contactViewModel = contactViewModel
+            )
+        }
+    }
+}
+

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/navigation/Screen.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/navigation/Screen.kt
@@ -1,0 +1,7 @@
+package com.madcamp.phonebook.navigation
+
+class Screen {
+    val MainScreen = "MainScreen"
+    val ContactListScreen = "ContactListScreen"
+    val ContactDetailScreen = "ContactDetailScreen"
+}

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/TabLayout.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/TabLayout.kt
@@ -15,18 +15,23 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.pagerTabIndicatorOffset
 import com.google.accompanist.pager.rememberPagerState
 import com.madcamp.phonebook.domain.model.Contact
+import com.madcamp.phonebook.presentation.contact.ContactListScreen
 import com.madcamp.phonebook.ui.theme.Blue400
 import kotlinx.coroutines.launch
 
 @ExperimentalPagerApi
 @Composable
-fun TabLayout(contactList: List<Contact>) {
+fun TabLayout(
+    contactList: List<Contact>,
+    navController: NavController
+) {
     val pagerState = rememberPagerState(pageCount = 3)
 
     Column(
@@ -49,7 +54,7 @@ fun TabLayout(contactList: List<Contact>) {
             }
         }
         Tabs(pagerState = pagerState)
-        TabsContent(pagerState = pagerState, contactList = contactList)
+        TabsContent(pagerState = pagerState, contactList = contactList, navController = navController)
     }
 }
 
@@ -98,11 +103,16 @@ fun Tabs(pagerState: PagerState) {
 
 @ExperimentalPagerApi
 @Composable
-fun TabsContent(pagerState: PagerState, contactList: List<Contact>) {
+fun TabsContent(
+    pagerState: PagerState,
+    contactList: List<Contact>,
+    navController: NavController,
+    onClick: () -> Unit = {}
+) {
 
     HorizontalPager(state = pagerState) { page ->
         when (page) {
-            0 -> ContactListScreen(contactList)
+            0 -> ContactListScreen(navController, contactList)
             1 -> {}
             2 -> TabContentScreen(data = "Welcome to Screen 3")
         }

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/contact/ContactDetailScreen.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/contact/ContactDetailScreen.kt
@@ -1,0 +1,196 @@
+package com.madcamp.phonebook.presentation.contact
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Create
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material.icons.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.filled.Phone
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.madcamp.phonebook.domain.model.Contact
+import com.madcamp.phonebook.navigation.Screen
+import com.madcamp.phonebook.presentation.contact.component.TextBox
+import com.madcamp.phonebook.presentation.contact.viewmodel.ContactViewModel
+import com.madcamp.phonebook.ui.theme.Gray100
+import com.madcamp.phonebook.ui.theme.Gray200
+import com.madcamp.phonebook.ui.theme.Gray400
+
+@Composable
+fun ContactDetailScreen(
+    navController: NavController,
+    contactList: List<Contact>,
+    contactViewModel: ContactViewModel
+) {
+    val screen = Screen()
+    var isEditmode by remember { mutableStateOf(false) }
+    var contactNumber by remember { mutableStateOf(navController.currentBackStackEntry?.arguments?.getString("contactNumber") ?: "") }
+    var contact by remember { mutableStateOf(
+        contactList.find { it.phoneNumber == contactNumber } ?: Contact()
+        )
+    }
+    var contactName by remember { mutableStateOf(contact.name) }
+    var contactFavoriteStatus by remember { mutableStateOf(contact.favoriteStatus) }
+
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 20.dp, vertical = 50.dp)
+            .padding(end = 30.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Icon(
+                imageVector = Icons.Filled.KeyboardArrowLeft,
+                modifier = Modifier
+                    .size(50.dp)
+                    .clickable { navController.navigate(screen.MainScreen) },
+                contentDescription = "back_button",
+                tint = Color.Black
+            )
+
+            Icon(
+                imageVector = if (contactFavoriteStatus) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
+                modifier = Modifier
+                    .size(35.dp)
+                    .clickable {
+                        contactFavoriteStatus = !contactFavoriteStatus
+                    },
+                contentDescription = "contact_star",
+                tint = Color.Black
+            )
+        }
+        Spacer(modifier = Modifier.height(50.dp))
+
+        Box(
+            modifier = Modifier
+                .size(20.dp)
+                .clickable {
+                    isEditmode = true
+                }
+                .align(Alignment.End)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Create,
+                modifier = Modifier.size(20.dp),
+                contentDescription = "edit_mode",
+                tint = if (isEditmode) Gray400 else Color.Black
+            )
+        }
+        Spacer(modifier = Modifier.height(5.dp))
+
+        Column(
+            modifier = Modifier.padding(start = 20.dp)
+        ) {
+            TextBox(
+                type = "name",
+                text = contactName,
+                width = 320.dp,
+                height = 65.dp,
+                boxColor = Gray100,
+                readOnly = !isEditmode,
+                onValueChange = { newText ->
+                    contactName = newText
+                }
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                text = "* 관련 정보 이슈로 전화번호는 변경이 불가합니다.",
+                fontSize = 13.sp,
+                fontWeight = FontWeight.ExtraBold,
+                fontFamily = FontFamily.SansSerif,
+                color = Gray400
+            )
+
+            TextBox(
+                type = "phone number",
+                text = formatPhoneNumber(contactNumber),
+                width = 320.dp,
+                height = 65.dp,
+                boxColor = Gray100,
+                readOnly = true,
+                textColor = if (isEditmode) Gray400 else Color.Black
+            )
+        }
+        Spacer(modifier = Modifier.height(70.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(120.dp, 55.dp)
+                    .clip(RoundedCornerShape(50))
+                    .background(Gray200)
+                    .border(1.dp, Color.Black, RoundedCornerShape(50))
+                    .clickable {
+                        contactViewModel.initiatePhoneCall(contactNumber)
+                    },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Phone,
+                    modifier = Modifier.size(30.dp),
+                    contentDescription = "call_button",
+                    tint = Color.Black
+                )
+            }
+
+            Box(
+                modifier = Modifier
+                    .size(120.dp, 55.dp)
+                    .clip(RoundedCornerShape(50))
+                    .background(Gray200)
+                    .border(1.dp, Color.Black, RoundedCornerShape(50))
+                    .clickable {
+                        contactViewModel.initiateSendMessage(contactNumber)
+                    },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Email,
+                    modifier = Modifier.size(30.dp),
+                    contentDescription = "message_button",
+                    tint = Color.Black
+                )
+            }
+        }
+
+    }
+}

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/contact/ContactListScreen.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/contact/ContactListScreen.kt
@@ -1,15 +1,12 @@
-package com.madcamp.phonebook.presentation
+package com.madcamp.phonebook.presentation.contact
 
-import android.app.Activity
-import android.content.Context
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -20,28 +17,34 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import com.madcamp.phonebook.domain.model.Contact
+import com.madcamp.phonebook.navigation.Screen
 import com.madcamp.phonebook.ui.theme.Gray200
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ContactListScreen(
+    navController: NavController,
     contactList: List<Contact>
 ) {
+    val screen = Screen()
+
     Column(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
-        val activity = LocalContext.current as Activity
-
-        val grouped = contactList.groupBy {
-            it.name.first().getKoreanConsonant()
+        val grouped = if (contactList != mutableListOf(Contact())) {
+            contactList.groupBy {
+                it.name.first().getKoreanConsonant()
+            }
+        } else {
+            emptyMap()
         }
 
         val sortedGrouped = grouped.toSortedMap()
@@ -49,12 +52,15 @@ fun ContactListScreen(
         if (contactList.isNotEmpty()) {
             LazyColumn {
                 sortedGrouped.forEach { (initial, contactsForInitial) ->
+
                     stickyHeader {
                         CharacterHeader(initial)
                     }
 
                     items(contactsForInitial) { contact ->
-                        ContactListItem(contact)
+                        ContactListItem(contact, onCLick = {
+                            navController.navigate(screen.ContactDetailScreen + "/${contact.phoneNumber}")
+                        })
                     }
                 }
             }
@@ -67,6 +73,7 @@ fun ContactListScreen(
         }
     }
 }
+
 
 // header 표기를 위한 변환
 fun Char.getKoreanConsonant(): Char {
@@ -112,11 +119,15 @@ fun CharacterHeader(char: Char) {
 }
 
 @Composable
-fun ContactListItem(contact: Contact) {
+fun ContactListItem(
+    contact: Contact,
+    onCLick: () -> Unit = {}
+) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(2.dp),
+            .padding(2.dp)
+            .clickable { onCLick() },
         backgroundColor = Color.White
     ) {
         Column(

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/contact/component/TextBox.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/contact/component/TextBox.kt
@@ -1,0 +1,59 @@
+package com.madcamp.phonebook.presentation.contact.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.madcamp.phonebook.ui.theme.Gray400
+
+@Composable
+fun TextBox(
+    type: String = "",
+    text: String,
+    width: Dp,
+    height: Dp,
+    onClick: () -> Unit = {},
+    onValueChange: (String) -> Unit = {},
+    boxColor: Color,
+    textColor: Color = Color.Black,
+    readOnly: Boolean
+) {
+    TextField(
+        modifier = Modifier
+            .width(width)
+            .height(height)
+            .padding(0.dp)
+            .clickable { onClick() },
+        textStyle = TextStyle(fontSize = 22.sp, fontWeight = FontWeight.Bold),
+        value = text,
+        onValueChange = onValueChange,
+        singleLine = true,
+        placeholder = {
+            Text(
+                text = type,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold
+            )
+        },
+        colors = TextFieldDefaults.textFieldColors(
+            textColor = textColor,
+            cursorColor = Color.Black,
+            placeholderColor = Gray400,
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+            backgroundColor = boxColor
+        ),
+        shape = RoundedCornerShape(20),
+        readOnly = readOnly
+    )
+}

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/contact/viewmodel/ContactViewModel.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/contact/viewmodel/ContactViewModel.kt
@@ -1,0 +1,29 @@
+package com.madcamp.phonebook.presentation.contact.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+
+class ContactViewModel : ViewModel() {
+    var phoneCallListener: PhoneCallListener? = null
+    var sendMessageListener: SendMessageListener? = null
+    interface PhoneCallListener {
+        fun makePhoneCall(phoneNumber: String)
+    }
+
+    interface SendMessageListener {
+        fun sendMessage(phoneNumber: String)
+    }
+
+    fun initiatePhoneCall(phoneNumber: String) {
+        viewModelScope.launch {
+            phoneCallListener?.makePhoneCall(phoneNumber)
+        }
+    }
+
+    fun initiateSendMessage(phoneNumber: String) {
+        viewModelScope.launch {
+            sendMessageListener?.sendMessage(phoneNumber)
+        }
+    }
+}

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/ui/theme/Color.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/ui/theme/Color.kt
@@ -17,3 +17,4 @@ val Gray100 = Color(0XFFF5F5F5)
 val Gray200 = Color(0xFFEEEEEE)
 val Gray400 = Color(0xFFBDBDBD)
 
+val Green300 = Color(0xFFA3C585)


### PR DESCRIPTION
## 변경 사항 요약

: 연락처를 눌렀을 때 해당 연락처의 상세 정보를 볼 수 있는 상세 페이지를 구현했습니다. 
: NavGraph를 추가하여 navigation을 통해 contact 기능에서 페이지 간의 이동을 구현했습니다. 

## 변경 사항 상세 내역

: 연락처를 눌렀을 때 해당 연락처의 상세 페이지로 이동하면, 해당 연락처의 상세 정보를 볼 수 있고 해당 연락처로 곧바로 전화/문자를 할 수 있도록 연결해주는 기능을 구현하였습니다. 

## 구현 영상
[Screen_recording_20240101_113127.webm](https://github.com/wona825/madcamp_week1/assets/81519167/80b5c670-a444-407b-8f96-372c50ab5cb2)

## 비고 
리뷰 부탁드립니다 :)
