### PR TITLE
이름/전화번호를 통한 연락처 검색 기능 구현 

### DIFF
--- a/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/contact/component/SearchBox.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/contact/component/SearchBox.kt
@@ -1,0 +1,78 @@
+package com.madcamp.phonebook.presentation.contact.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.madcamp.phonebook.ui.theme.Gray100
+import com.madcamp.phonebook.ui.theme.Gray200
+import com.madcamp.phonebook.ui.theme.Gray400
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun SearchBox(
+    text: String,
+    placeholder: String,
+    onClickIcon: () -> Unit = {},
+    onValueChange: (String) -> Unit,
+    submit: () -> Unit = {}
+){
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    TextField(
+        modifier = Modifier
+            .size(370.dp, 50.dp)
+            .clip(RoundedCornerShape(50))
+            .clickable {},
+        textStyle = TextStyle(
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.Black
+        ),
+        value = text,
+        placeholder = {
+            Text(
+                text = placeholder,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Medium
+            )
+        },
+        onValueChange = onValueChange,
+        colors = TextFieldDefaults.textFieldColors(
+            textColor = Color.Black,
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent,
+            disabledIndicatorColor = Color.Transparent,
+            placeholderColor = Gray400,
+            backgroundColor = Gray100
+        ),
+        trailingIcon = {
+            Icon(Icons.Filled.Search, "", Modifier.clickable { onClickIcon() })
+        },
+        keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Search),
+        keyboardActions = KeyboardActions(
+            onSearch = {
+                submit()
+                keyboardController?.hide()
+            }),
+        readOnly = false
+    )
+}


### PR DESCRIPTION
## 변경 사항 요약

: 연락처 리스트 조회 페이지에서 연락처 검색 기능을 구현했습니다. 


## 변경 사항 상세 내역

: 이름/전화번호를 입력하면 해당 이름/전화번호 부분을 포함하는 연락처가 조회되도록 연락처 검색 기능을 구현했습니다.

## 구현 영상
[Screen_recording_20240101_134634.webm](https://github.com/wona825/madcamp_week1/assets/81519167/2b8977ad-0260-4932-b306-06596609c79c)

## 비고 
리뷰 부탁드립니다 :)
