### PR TITLE
갤러리 기능 구현

### DIFF
--- a/phonebook/app/src/main/AndroidManifest.xml
+++ b/phonebook/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
 
     <application

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/MainActivity.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/MainActivity.kt
@@ -6,10 +6,12 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.database.Cursor
 import android.net.Uri
+import android.os.Build
 import androidx.activity.compose.setContent
 import android.os.Bundle
 import android.provider.ContactsContract
 import androidx.activity.ComponentActivity
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -23,7 +25,18 @@ import com.madcamp.phonebook.ui.theme.PhonebookTheme
 class MainActivity : ComponentActivity(), ContactViewModel.PhoneCallListener, ContactViewModel.SendMessageListener {
     private lateinit var contactViewModel: ContactViewModel
 
+    data class favorites (
+        var name: String,
+        val image: Uri?
+    )
+
     private var contactList by mutableStateOf<List<Contact>>(emptyList())
+
+    private var getlist: MutableList<favorites> =  mutableListOf<favorites>()  // list of favorites
+
+    private var delete_index:Int = -1
+
+    @RequiresApi(Build.VERSION_CODES.R)
     override fun onCreate(savedInstanceState: Bundle?)
     {
         super.onCreate(savedInstanceState)
@@ -36,7 +49,7 @@ class MainActivity : ComponentActivity(), ContactViewModel.PhoneCallListener, Co
 
         setContent {
             PhonebookTheme {
-                NavGraph(activity = this, contactList = contactList, contactViewModel = contactViewModel)
+                NavGraph(activity = this, contactList = contactList, contactViewModel = contactViewModel, favoriteList = getlist, delete_index)
             }
         }
 

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/navigation/NavGraph.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/navigation/NavGraph.kt
@@ -1,7 +1,11 @@
 package com.madcamp.phonebook.navigation
 
+import android.net.Uri
+import android.os.Build
 import androidx.activity.ComponentActivity
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -13,13 +17,20 @@ import com.madcamp.phonebook.presentation.contact.ContactDetailScreen
 import com.madcamp.phonebook.presentation.contact.ContactListScreen
 import com.madcamp.phonebook.presentation.contact.viewmodel.ContactViewModel
 import com.madcamp.phonebook.presentation.TabLayout
+import com.madcamp.phonebook.presentation.gallery.component.Gallery_Tab
+import com.madcamp.phonebook.MainActivity.favorites
+import com.madcamp.phonebook.presentation.gallery.component.Image_Tab
 
+
+@RequiresApi(Build.VERSION_CODES.R)
 @OptIn(ExperimentalPagerApi::class)
 @Composable
 fun NavGraph(
     activity: ComponentActivity,
     contactList: List<Contact>,
-    contactViewModel: ContactViewModel
+    contactViewModel: ContactViewModel,
+    favoriteList: MutableList<favorites>,
+    delete_index: Int
 ) {
     val screen = Screen()
     val navController = rememberNavController()
@@ -29,7 +40,7 @@ fun NavGraph(
         startDestination = screen.MainScreen
     ) {
         composable(screen.MainScreen) {
-            TabLayout(contactList, navController)
+            TabLayout(contactList, favoriteList, navController)
         }
 
         composable(screen.ContactListScreen) {
@@ -48,6 +59,15 @@ fun NavGraph(
                 contactViewModel = contactViewModel
             )
         }
+        composable(screen.GalleryScreen){
+            Gallery_Tab(navController, favoriteList)
+        }
+
+        composable(screen.GalleryDetailScreen+"/{index}", arguments = listOf(navArgument("index") { type = NavType.IntType })) { backStackEntry ->
+            val index = backStackEntry.arguments?.getInt("index") ?: -1
+            Image_Tab(navController, favoriteList, delete_index, favoriteList[index])
+        }
+
     }
 }
 

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/navigation/Screen.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/navigation/Screen.kt
@@ -4,4 +4,6 @@ class Screen {
     val MainScreen = "MainScreen"
     val ContactListScreen = "ContactListScreen"
     val ContactDetailScreen = "ContactDetailScreen"
+    val GalleryScreen = "Gallery_Tab"
+    val GalleryDetailScreen = "Image_Tab"
 }

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/TabLayout.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/TabLayout.kt
@@ -1,5 +1,7 @@
 package com.madcamp.phonebook.presentation
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
@@ -23,6 +25,8 @@ import com.google.accompanist.pager.pagerTabIndicatorOffset
 import com.google.accompanist.pager.rememberPagerState
 import com.madcamp.phonebook.domain.model.Contact
 import com.madcamp.phonebook.presentation.contact.ContactListScreen
+import com.madcamp.phonebook.presentation.gallery.component.Gallery_Tab
+import com.madcamp.phonebook.MainActivity.favorites
 import com.madcamp.phonebook.ui.theme.Blue400
 import kotlinx.coroutines.launch
 
@@ -30,6 +34,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun TabLayout(
     contactList: List<Contact>,
+    favoriteList: MutableList<favorites>,
     navController: NavController
 ) {
     val pagerState = rememberPagerState(pageCount = 3)
@@ -54,7 +59,7 @@ fun TabLayout(
             }
         }
         Tabs(pagerState = pagerState)
-        TabsContent(pagerState = pagerState, contactList = contactList, navController = navController)
+        TabsContent(pagerState = pagerState, contactList = contactList, favoriteList, navController = navController)
     }
 }
 
@@ -101,11 +106,13 @@ fun Tabs(pagerState: PagerState) {
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.R)
 @ExperimentalPagerApi
 @Composable
 fun TabsContent(
     pagerState: PagerState,
     contactList: List<Contact>,
+    favoriteList: MutableList<favorites>,
     navController: NavController,
     onClick: () -> Unit = {}
 ) {
@@ -113,7 +120,7 @@ fun TabsContent(
     HorizontalPager(state = pagerState) { page ->
         when (page) {
             0 -> ContactListScreen(navController, contactList)
-            1 -> {}
+            1 -> Gallery_Tab(navController = navController, favoritelist = favoriteList)
             2 -> TabContentScreen(data = "Welcome to Screen 3")
         }
     }

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/gallery/component/GalleryTab.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/gallery/component/GalleryTab.kt
@@ -1,0 +1,122 @@
+package com.madcamp.phonebook.presentation.gallery.component
+
+import android.Manifest
+import android.net.Uri
+import android.os.Build
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.madcamp.phonebook.Gallery_Navigation.Gallery_Tab.Gallery_Screen.SearchTab
+import com.madcamp.phonebook.Gallery_Navigation.Gallery_Tab.Gallery_Screen.Show_Gallery_Image
+import com.madcamp.phonebook.MainActivity.favorites
+
+@RequiresApi(Build.VERSION_CODES.R)
+@Composable
+fun Gallery_Tab(navController: NavController, favoritelist: MutableList<favorites>){
+
+    var Perm_flag by remember{ mutableStateOf(false) } // Does permission flag is on or not?
+    var Check_isGranted by remember{ mutableStateOf(false) } // Does check is granted or not?
+    var pre_checked by remember{ mutableStateOf(false) }  // Onclick makes authority check and make pre_checked.
+    var add_image by remember{ mutableStateOf(false) }  // Onclick makes image accessing.
+    var imageUri by remember { mutableStateOf<Uri?>(null) }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()) {
+            uri: Uri? ->
+        imageUri = uri
+        imageUri?.let {
+            favoritelist.add(favorites("#Favorite", imageUri))
+        }
+        Log.d("add", "add: $favoritelist")
+        add_image = false
+    }
+
+    val write_external_storage_launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+        onResult = {
+                isGranted -> Check_isGranted = isGranted
+        }
+    )
+
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(0.dp)
+    ){
+        SearchTab(favoritelist = favoritelist)
+
+
+        Box(
+            modifier = Modifier.weight(8f)
+        ) {
+            LazyColumn(
+                contentPadding = PaddingValues(0.dp, 0.dp)
+            ) {
+
+                item {
+
+                    Show_Gallery_Image(navController, favoritelist = favoritelist)
+
+                }
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .weight(1f)
+                .offset(y = (-5).dp),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            FilledTonalButton(
+
+                onClick = {
+                    Perm_flag = true
+                    add_image = true
+
+                },
+
+            ) {
+                Text("Add New Image")
+            }
+
+            if (Perm_flag && (!pre_checked)) {
+                write_external_storage_launcher.launch(
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+                )
+                Perm_flag = false
+                pre_checked = true
+            }
+
+            if (Check_isGranted) {
+                if (add_image) {
+                    SideEffect {
+                        launcher.launch("image/*")
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/gallery/component/ImageDetailedScreen.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/gallery/component/ImageDetailedScreen.kt
@@ -1,0 +1,123 @@
+package com.madcamp.phonebook.presentation.gallery.component
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.madcamp.phonebook.MainActivity.favorites
+
+@Composable
+fun Image_Tab(navController: NavHostController, favorite_list: MutableList<favorites>, delete_index: Int, favorite: favorites){
+
+    Column() {
+        // 1st Line
+        Box(
+            modifier = Modifier
+                //.fillMaxWidth()
+                .weight(1f)
+                .border(2.dp, Color.Black)
+        ){
+            Row(){
+                // Return Button
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .clickable {
+                            navController.navigate("Gallery_Tab")
+                        }
+                ){
+                    Icon(imageVector = Icons.Default.Close, contentDescription = null, modifier = Modifier
+                        .fillMaxSize() // Adjust the size of the icon
+                        .padding(end = 8.dp)  // Adjust the padding if needed
+                        .align(Alignment.Center))
+                }
+
+                // Empty Box
+                Box(
+                    modifier = Modifier
+                        .weight(6f)
+                ){
+                }
+
+                // Trash Bin
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .clickable{
+                            //delete_index = favorite_list.indexOf(favorite)
+                            navController.navigate("Gallery_Tab")
+                        }
+                ){
+                    Icon(imageVector = Icons.Default.Delete, contentDescription = null, modifier = Modifier
+                        .fillMaxSize() // Adjust the size of the icon
+                        .padding(end = 8.dp)  // Adjust the padding if needed
+                        .align(Alignment.Center))
+                }
+            }
+        }
+
+        // 2nd Line, Image
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(6f)
+                .border(2.dp, Color.Black)
+        ){
+
+        }
+
+        // 3rd Line
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .border(2.dp, Color.Black)
+        ){
+            Row(){
+
+                // Tags
+                Box(
+                    modifier = Modifier
+                        .weight(7f)
+                        .border(2.dp, Color.Black)
+                ){
+
+                }
+
+                // Like or Not
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .border(2.dp, Color.Black)
+                ){
+
+                }
+            }
+        }
+
+        // 4th Line, Description
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(4f)
+                .border(2.dp, Color.Black)
+        ){
+
+        }
+    }
+
+}

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/gallery/component/SearchTab.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/gallery/component/SearchTab.kt
@@ -1,0 +1,63 @@
+package com.madcamp.phonebook.Gallery_Navigation.Gallery_Tab.Gallery_Screen
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.madcamp.phonebook.MainActivity
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchTab(favoritelist: MutableList<MainActivity.favorites>){
+    var searchText by remember { mutableStateOf("") }
+
+    Row(
+        modifier = Modifier
+            .padding(5.dp)
+    ){
+        Icon(imageVector = Icons.Default.Search, contentDescription = null, modifier = Modifier
+            .size(40.dp)  // Adjust the size of the icon
+            .padding(end = 8.dp)  // Adjust the padding if needed
+            .align(Alignment.CenterVertically))
+
+        OutlinedTextField(
+            value = searchText,
+            onValueChange = { searchText = it },
+            label = { Text("Search") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Text,
+                imeAction = ImeAction.Search
+            ),
+            // search logic
+//            keyboardActions = KeyboardActions(
+//                onSearch = {
+//                    // Handle search action
+//                    performSearch(searchText, context)
+//                }
+//            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp)
+                .height(40.dp)
+        )
+    }
+}

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/gallery/component/ShowImage.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/gallery/component/ShowImage.kt
@@ -1,0 +1,57 @@
+package com.madcamp.phonebook.Gallery_Navigation.Gallery_Tab.Gallery_Screen
+
+import android.graphics.Bitmap
+import android.graphics.ImageDecoder
+import android.os.Build
+import android.provider.MediaStore
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.madcamp.phonebook.MainActivity
+
+// Show each image on the screen.
+@RequiresApi(Build.VERSION_CODES.R)
+@Composable
+fun FavoriteImage(navController:NavController, favorite: MainActivity.favorites, favorite_list: MutableList<MainActivity.favorites>){
+
+    val bitmap = remember { mutableStateOf<Bitmap?>(null) }
+    val imageUri = favorite.image
+    val context = LocalContext.current
+    val screen_width = ((getScreenWidth(LocalContext.current).toDouble()) / 3).toInt()
+
+    imageUri?.let {
+        if (Build.VERSION.SDK_INT < 28) {
+            bitmap.value = MediaStore.Images.Media.getBitmap(context.contentResolver, it)
+        }
+        else {
+            val source = ImageDecoder.createSource(context.contentResolver, it)
+            bitmap.value = ImageDecoder.decodeBitmap(source)
+        }
+        bitmap.value?.let {btm ->
+            Image(
+                bitmap = btm.asImageBitmap(),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .width(screen_width.dp)
+                    .height(screen_width.dp)
+                    .clickable {
+                        val this_index = favorite_list.indexOf(favorite)
+                        navController.navigate("Image_Tab/${this_index}")
+                    }
+
+            )
+        }
+    }
+}

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/gallery/component/ShowImageName.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/gallery/component/ShowImageName.kt
@@ -1,0 +1,92 @@
+package com.madcamp.phonebook.Gallery_Navigation.Gallery_Tab.Gallery_Screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.madcamp.phonebook.MainActivity
+
+
+// Get an image name from user.
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class)
+@Composable
+fun get_image_name(favorite: MainActivity.favorites, favorite_list: MutableList<MainActivity.favorites>){
+
+    var Click_Flag by remember{ mutableStateOf(false) }
+    var text by remember { mutableStateOf("Edit") }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val index_getlist = favorite_list.indexOf(favorite)
+    val screen_width = ((getScreenWidth(LocalContext.current).toDouble()) / 3).toInt()
+
+    Box(
+        modifier = Modifier
+            .background(if (Click_Flag) Color.White else Color.White)
+            .clickable {
+                Click_Flag = !Click_Flag
+                if (Click_Flag) {
+                    keyboardController?.show()
+                }
+            }
+            .width(screen_width.dp)
+            .padding(top = 3.dp, bottom = 3.dp)
+    ){
+        if(Click_Flag){
+            TextField(
+                textStyle = TextStyle(fontSize = 15.sp),
+                value = text,
+                onValueChange = { newText ->
+                    text = newText
+                },
+                keyboardOptions = KeyboardOptions.Default.copy(
+                    imeAction = ImeAction.Done
+                ),
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        // Handle the "Done" action
+                        Click_Flag = !Click_Flag
+                        favorite_list[index_getlist].name = "#" + text
+                        keyboardController?.hide()
+                    }
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(color = Color.LightGray)
+                    .heightIn(max = 50.dp)
+            )
+        }
+        else{
+            Text(
+                fontSize = 15.sp,
+                text = favorite.name,
+                color = Color.Black,
+                modifier = Modifier
+                    .widthIn(max = screen_width.dp)
+                    .heightIn(max = 20.dp)
+
+            )
+        }
+    }
+}

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/gallery/component/ShowImageOnFile.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/gallery/component/ShowImageOnFile.kt
@@ -1,0 +1,38 @@
+package com.madcamp.phonebook.Gallery_Navigation.Gallery_Tab.Gallery_Screen
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import com.madcamp.phonebook.MainActivity
+
+@Composable
+fun Show_Gallery_Image(navController: NavController, favoritelist: MutableList<MainActivity.favorites>){
+    for (index in favoritelist.indices step 3) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            //horizontalArrangement = Arrangement.SpaceBetween // Arrange child elements with even space
+        ) {
+
+            // Elem1 (Item)
+            FavoriteItem(
+                navController,
+                favorite = favoritelist[index],
+                favorite_list = favoritelist
+            )
+
+            // Elem2. Second Item
+            if ((index + 1) == favoritelist.size) {
+              // do nothing
+
+            } else if ((index + 2) == favoritelist.size) {
+                FavoriteItem(navController, favorite = favoritelist[index + 1], favorite_list = favoritelist)
+            } else {
+                FavoriteItem(navController, favorite = favoritelist[index + 1], favorite_list = favoritelist)
+                FavoriteItem(navController, favorite = favoritelist[index + 2], favorite_list = favoritelist)
+            }
+
+        }
+    }
+}

--- a/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/gallery/component/ShowItem.kt
+++ b/phonebook/app/src/main/java/com/madcamp/phonebook/presentation/gallery/component/ShowItem.kt
@@ -1,0 +1,38 @@
+package com.madcamp.phonebook.Gallery_Navigation.Gallery_Tab.Gallery_Screen
+
+import android.content.Context
+import android.os.Build
+import android.util.DisplayMetrics
+import android.view.WindowManager
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavController
+import com.madcamp.phonebook.MainActivity
+
+@RequiresApi(Build.VERSION_CODES.R)
+fun getScreenWidth(context: Context): Int {
+    val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    val displayMetrics = DisplayMetrics()
+    context.display?.getRealMetrics(displayMetrics)
+    return ((displayMetrics.widthPixels).toDouble() / 3).toInt()
+}
+
+
+// Show each item on the screen. Each item consists of image and the description. (2 elements)
+@RequiresApi(Build.VERSION_CODES.R)
+@Composable
+fun FavoriteItem(navController: NavController, favorite: MainActivity.favorites, favorite_list: MutableList<MainActivity.favorites>){
+    Column{
+        // Elem1. image
+        FavoriteImage(navController, favorite = favorite, favorite_list = favorite_list)
+        // Elem2. text
+        Row(){
+            get_image_name(favorite, favorite_list)
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
## 변경 사항 요약

: 갤러리에서 디바이스 저장소를 통한 이미지 불러오기 기능을 구현했습니다.
: NavGraph 상의 navigation을 통해 gallery 기능 간 이동을 구현했습니다.

## 변경 사항 상세 내역

: 갤러리 탭에서 Add to Image 버튼을 통해 디바이스의 파일을 가져올 수 있고, 가져온 파일의 이름을 수정할 수 있는 기능을 구현했습니다.

## 구현 영상
![Screenshot_20240101-134812_phonebook 1](https://github.com/wona825/madcamp_week1/assets/70854569/94f8fda9-426e-4f83-9f36-39a240d918f9)


## 비고 
리뷰 부탁드립니다 :)
